### PR TITLE
Add constant conditions

### DIFF
--- a/src/components/UsageGuide.tsx
+++ b/src/components/UsageGuide.tsx
@@ -5,8 +5,8 @@ const UsageGuide = ({ className }: { className: string }) => (
     <h2>Usage guide</h2>
     <div>
       <p>
-        The first (non-comment, non-empty) line should be the variable list separated by semicolons{' '}
-        <b>;</b>
+        The first (non-comment, non-empty) line should be the variable list
+        separated by semicolons <b>;</b>
         <br />
         You can put whitespaces between the expressions (before or after
         semicolons, beginning or end of a line). Whitespaces in the middle of
@@ -16,7 +16,8 @@ const UsageGuide = ({ className }: { className: string }) => (
         Floating point numbers use a dot <b>.</b>
       </p>
       <p>
-        You can leave lines empty, or create a commented line beginning with <code>&#47;&#47;</code>
+        You can leave lines empty, or create a commented line beginning with{' '}
+        <code>&#47;&#47;</code>
       </p>
       <p>
         The variables have the following structure:
@@ -39,18 +40,21 @@ const UsageGuide = ({ className }: { className: string }) => (
           <li>
             <code>variableName(num,0.02)</code>
             <br />
-            variable name wuth Number type, where the precision is given, i.e., 0.02
+            variable name wuth Number type, where the precision is given, i.e.,
+            0.02
           </li>
         </ul>
       </p>
       <p>
-        Next, the logical conditions are listed line by line separated with semicolons.
-        The semicolons represents semantically AND operators.
-        <br /><br />
+        Next, the logical conditions are listed line by line separated with
+        semicolons. The semicolons represents semantically AND operators.
+        <br />
+        <br />
         The atomic conditions can be:
         <ul>
           <li>
-            *<br />
+            <code>*</code>
+            <br />
             if there is no constraint on this variable
           </li>
           <li>
@@ -59,7 +63,8 @@ const UsageGuide = ({ className }: { className: string }) => (
             if the variable is Boolean
           </li>
           <li>
-            Logical operators followed by a Number, e.g.<br />
+            Logical operators followed by a Number, e.g.
+            <br />
             <code>&lt;30</code> or <code>!=12.62</code>
             <br />
             The possible operators: <code>&lt; &lt;= &gt; &gt;= = !=</code>
@@ -71,6 +76,12 @@ const UsageGuide = ({ className }: { className: string }) => (
             <br />
           </li>
         </ul>
+        You can make an atomic condition a constant by prefixing it with a{' '}
+        <code>$</code>, like: <code>$&gt;=0</code>. <br />
+        You can use constants, where a condition will always be true according
+        to the requirements. For example, an age can never be a negative number,
+        we can set it to <code>$&gt;=0</code>. <br />
+        <br />
         Example: Let the condition be the following:
         <br />
         <code>
@@ -79,7 +90,7 @@ const UsageGuide = ({ className }: { className: string }) => (
         </code>
         <br />
         Then the appropriate input is: <br />
-          <code>true; (100,199.99]; &gt;20</code>
+        <code>true; (100,199.99]; &gt;20</code>
       </p>
       <p>
         Another example with several conditions:

--- a/src/logic/models/dtos.ts
+++ b/src/logic/models/dtos.ts
@@ -16,6 +16,8 @@ export enum Expression {
 
 export interface IInput {
   expression: Expression;
+  isConstant: boolean;
+
   intersectsWith(other: IInput): boolean;
   intersect(other: IInput): IInput;
   toString(): string;
@@ -24,10 +26,16 @@ export interface IInput {
 export class BoolDTO implements IInput {
   expression: Expression;
   boolVal: boolean;
+  isConstant: boolean;
 
-  constructor(expression: Expression, boolVal: boolean) {
+  constructor(
+    expression: Expression,
+    boolVal: boolean,
+    isConstant: boolean = false,
+  ) {
     this.expression = expression;
     this.boolVal = boolVal;
+    this.isConstant = isConstant;
   }
 
   intersectsWith(other: IInput): boolean {
@@ -63,6 +71,7 @@ export class BoolDTO implements IInput {
 
 export class MissingVariableDTO implements IInput {
   expression = Expression.MissingVariable;
+  isConstant = false;
 
   intersectsWith(other: IInput): boolean {
     return true;
@@ -85,6 +94,7 @@ export interface IsOpen {
 
 export class IntervalDTO implements IInput {
   expression: Expression;
+  isConstant: boolean;
   interval: Interval;
   isOpen: IsOpen;
   precision: number;
@@ -94,11 +104,13 @@ export class IntervalDTO implements IInput {
     interval: Interval,
     precision: number,
     isOpen: IsOpen = { hi: false, lo: false },
+    isConstant: boolean = false,
   ) {
     this.expression = expression;
     this.interval = interval;
     this.precision = precision;
     this.isOpen = isOpen;
+    this.isConstant = isConstant;
   }
 
   intersectsWith(other: IInput): boolean {

--- a/src/logic/models/utils.ts
+++ b/src/logic/models/utils.ts
@@ -24,6 +24,7 @@ export function createUnaryIntervalDTO(
   expression: Expression,
   num: number,
   precision: number,
+  isConstant: boolean,
 ): IntervalDTO {
   switch (expression) {
     case Expression.LessThan:
@@ -32,6 +33,7 @@ export function createUnaryIntervalDTO(
         new Interval(-Infinity, num),
         precision,
         { lo: true, hi: true },
+        isConstant,
       );
 
     case Expression.LessThanOrEqualTo:
@@ -40,6 +42,7 @@ export function createUnaryIntervalDTO(
         new Interval(-Infinity, num),
         precision,
         { lo: true, hi: false },
+        isConstant,
       );
 
     case Expression.GreaterThan:
@@ -48,6 +51,7 @@ export function createUnaryIntervalDTO(
         new Interval(num, Infinity),
         precision,
         { lo: true, hi: true },
+        isConstant,
       );
 
     case Expression.GreaterThanOrEqualTo:
@@ -56,19 +60,32 @@ export function createUnaryIntervalDTO(
         new Interval(num, Infinity),
         precision,
         { lo: false, hi: true },
+        isConstant,
       );
 
     case Expression.EqualTo:
-      return new IntervalDTO(expression, new Interval(num, num), precision, {
-        lo: false,
-        hi: false,
-      });
+      return new IntervalDTO(
+        expression,
+        new Interval(num, num),
+        precision,
+        {
+          lo: false,
+          hi: false,
+        },
+        isConstant,
+      );
 
     case Expression.NotEqualTo:
-      return new IntervalDTO(expression, new Interval(num, num), precision, {
-        lo: false,
-        hi: false,
-      });
+      return new IntervalDTO(
+        expression,
+        new Interval(num, num),
+        precision,
+        {
+          lo: false,
+          hi: false,
+        },
+        isConstant,
+      );
 
     default:
       throw new Error(

--- a/src/logic/testCaseGenerator.ts
+++ b/src/logic/testCaseGenerator.ts
@@ -22,6 +22,8 @@ export function generateTestCases(inputs: IInput[]): NTuple[] {
 const calculateInOnPatterns1 = (inputs: IInput[]): IInput[] =>
   // eslint-disable-next-line array-callback-return
   inputs.map((input) => {
+    if (input.isConstant) return input;
+
     switch (input.expression) {
       case Expression.LessThan:
       case Expression.LessThanOrEqualTo:
@@ -50,6 +52,8 @@ const calculateInOnPatterns1 = (inputs: IInput[]): IInput[] =>
 const calculateInOnPatterns2 = (inputs: IInput[]): IInput[] =>
   // eslint-disable-next-line array-callback-return
   inputs.map((input) => {
+    if (input.isConstant) return input;
+
     switch (input.expression) {
       case Expression.LessThan:
       case Expression.LessThanOrEqualTo:
@@ -78,6 +82,8 @@ const calculateInOnPatterns2 = (inputs: IInput[]): IInput[] =>
 const baseline = (inputs: IInput[]): IInput[] =>
   // eslint-disable-next-line array-callback-return
   inputs.map((input) => {
+    if (input.isConstant) return input;
+
     switch (input.expression) {
       case Expression.LessThan:
       case Expression.LessThanOrEqualTo:
@@ -106,6 +112,7 @@ function OffOut(inputs: IInput[]): IInput[][] {
 
   for (let i = 0; i < inputs.length; ++i) {
     if (inputs[i] instanceof MissingVariableDTO) continue;
+    if (inputs[i].isConstant) continue;
 
     var based1 = baseline(inputs);
     var based2 = baseline(inputs);


### PR DESCRIPTION
Adds the option to create constant conditions. There won't be mangled during test case generation.
For example `$>20` will only have `(20,Infinity)` as a test case, the In, On, InIn and other cases won't be generated.